### PR TITLE
Fix old draft-07 schema in 2020 schema

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -438,9 +438,6 @@
                 "language": {
                     "$ref": "#/$defs/languageProp"
                 },
-                "referred_to_by": {
-                    "$ref": "#/$defs/referred_to_byProp"
-                },
                 "part": {
                     "description": "A list of one or more `Name` structures, which are parts of this `Name`",
                     "type": "array",

--- a/schema/core.json
+++ b/schema/core.json
@@ -1372,12 +1372,10 @@
                 {
                     "title": "Linked Art with Extensions",
                     "type": "array",
-                    "items": [
-                        {
-                            "type": "string",
-                            "format": "uri"
-                        }
-                    ]
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Fix #12, #8

AI helped fix and write this issue... :-/

The problem: schema/core.json declares $schema: draft 2020-12, but the ContextStringOrArray definition used the draft-07 tuple form of items (an array of subschemas):

```
"items": [
    { "type": "string", "format": "uri" }
]
```

In draft 2020-12, items must be a single schema (object or boolean) and applies to all array elements; the tuple/positional form was renamed to prefixItems. That's why the metaschema rejected /definitions/ContextStringOrArray/anyOf/1/items with "want boolean or object, but got array."

Since the intent is "an array of context URI strings," I changed it to apply the subschema to every item:

```
{
                    "title": "Linked Art with Extensions",
                    "type": "array",
                    "items": {
                        "type": "string",
                        "format": "uri"
                    }
                }
```