### PR TITLE
Update provenance schema to reference 'Right' instead of 'LegalRight' for establishes and invalidates properties

### DIFF
--- a/schema/provenance.json
+++ b/schema/provenance.json
@@ -158,8 +158,8 @@
 				"after": {"$ref": "core.json#/$defs/afterProp"},
 				"before": {"$ref": "core.json#/$defs/beforeProp"},
 
-				"establishes": {"title": "la:establishes", "description": "", "type": "array", "items": {"$ref": "core.json#/$defs/LegalRight"}},
-				"invalidates": {"title": "la:invalidates", "description": "", "type": "array", "items": {"$ref": "core.json#/$defs/LegalRight"}}
+				"establishes": {"title": "la:establishes", "description": "", "type": "array", "items": {"$ref": "core.json#/$defs/Right"}},
+				"invalidates": {"title": "la:invalidates", "description": "", "type": "array", "items": {"$ref": "core.json#/$defs/Right"}}
 			},
 			"required": ["type", "establishes"],
 			"additionalProperties": false	


### PR DESCRIPTION
Fix #7

Validating the schema failed on json-pointer to LegalRight in core.json. In documentation and in the schema Right is used.